### PR TITLE
onyx: cm-13.0-stable: remove bloat

### DIFF
--- a/onyx/cm-13.0-stable/local_manifest.xml
+++ b/onyx/cm-13.0-stable/local_manifest.xml
@@ -11,8 +11,11 @@
   <remove-project name="CyanogenMod/android_hardware_qcom_media" />
   <remove-project name="CyanogenMod/android_hardware_ril" />
   <remove-project name="CyanogenMod/android_packages_apps_AudioFX" />
+  <remove-project name="CyanogenMod/android_packages_apps_CMFileManager" />  
   <remove-project name="CyanogenMod/android_packages_apps_CMUpdater" />
   <remove-project name="CyanogenMod/android_packages_apps_Eleven" />
+  <remove-project name="CyanogenMod/android_packages_apps_Email" />
+  <remove-project name="CyanogenMod/android_packages_apps_Messaging" />
   <remove-project name="CyanogenMod/android_packages_apps_Screencast" />
   <remove-project name="CyanogenMod/android_packages_apps_Snap" />
   <remove-project name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" />


### PR DESCRIPTION
I don't believe many people actually use the stock email or messaging apps, and the majority of CM FIle Managers functionality can be achieved through Android's default storage browser. I don't believe any of the three are necessary and they are taking up more space than they are worth. That said, it is completely up to you :)