### PR TITLE
Revert "Add WireGuard via manifest"

### DIFF
--- a/oneplus3/cm-14.1/local_manifest.xml
+++ b/oneplus3/cm-14.1/local_manifest.xml
@@ -35,10 +35,6 @@
   <project path="packages/apps/WeatherProviders" name="sultanxda/android_packages_apps_WeatherProviders" revision="cm-14.1" />
   <project path="vendor/oneplus" name="sultanxda/proprietary_vendor_oneplus" revision="cm-14.1-sultan" />
 
-  <!--WireGuard-->
-  <remote name="zx2c4" fetch="https://git.zx2c4.com/" />
-  <project remote="zx2c4" name="android_kernel_wireguard" path="kernel/wireguard" revision="master" sync-s="true" />
-
  <!--Repositories to remove-->
   <remove-project name="platform/prebuilts/clang/darwin-x86/host/3.6" />
   <remove-project name="platform/prebuilts/clang/host/darwin-x86" />


### PR DESCRIPTION
This reverts commit a9efff7f197269dbf0c1dccb28ce9db6196887d3.

We're now integrating things directly into the kernel, so that builds
aren't dirty. It's also no longer necessary to bundle the tools inside
the ROM, since the APK provides an installer for that.

Merge this at the same time as https://github.com/sultanxda/android_kernel_oneplus_msm8996/pull/2.